### PR TITLE
Ignores the MissingHandlerException.

### DIFF
--- a/framework-tools-replay/pom.xml
+++ b/framework-tools-replay/pom.xml
@@ -134,6 +134,19 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>uk.gov.justice.services</groupId>
+            <artifactId>test-utils-core</artifactId>
+            <scope>test</scope>
+            <version>${framework.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/framework-tools-replay/src/test/java/uk/gov/justice/framework/tools/replay/AsyncStreamDispatcherTest.java
+++ b/framework-tools-replay/src/test/java/uk/gov/justice/framework/tools/replay/AsyncStreamDispatcherTest.java
@@ -4,15 +4,21 @@ package uk.gov.justice.framework.tools.replay;
 import static java.util.UUID.randomUUID;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
-import static uk.gov.justice.services.messaging.DefaultJsonEnvelope.envelope;
 import static uk.gov.justice.services.messaging.JsonObjectMetadata.metadataWithDefaults;
 import static uk.gov.justice.services.messaging.JsonObjectMetadata.metadataWithRandomUUID;
+import static uk.gov.justice.services.test.utils.core.matchers.JsonEnvelopeMatcher.jsonEnvelope;
+import static uk.gov.justice.services.test.utils.core.matchers.JsonEnvelopeMetadataMatcher.metadata;
+import static uk.gov.justice.services.test.utils.core.messaging.JsonEnvelopeBuilder.envelope;
 
+import uk.gov.justice.services.core.handler.exception.MissingHandlerException;
 import uk.gov.justice.services.event.buffer.core.repository.streamstatus.StreamStatus;
 import uk.gov.justice.services.event.buffer.core.repository.streamstatus.StreamStatusJdbcRepository;
 import uk.gov.justice.services.messaging.JsonEnvelope;
+import uk.gov.justice.services.test.utils.core.matchers.JsonEnvelopeMatcher;
 
 import java.util.List;
 import java.util.UUID;
@@ -77,6 +83,31 @@ public class AsyncStreamDispatcherTest {
     public void shouldThrowExceptionIfNoVersionInTheEnvelope() {
 
         asyncStreamDispatcher.dispatch(Stream.of(envelope().with(metadataWithDefaults().withStreamId(randomUUID())).build()));
+
+    }
+
+    @Test
+    public void shouldProcessStreamWhenThereIsNoHandlerDefined() {
+
+        final UUID streamId = randomUUID();
+
+        final JsonEnvelopeMatcher envelopeMatcherForEventWithoutHandler = jsonEnvelope()
+                .withMetadataOf(metadata().withName("event-without-handler"));
+
+        doThrow(new MissingHandlerException("Handler for event-without-handler not found"))
+                .when(envelopeDispatcher).dispatch(argThat(envelopeMatcherForEventWithoutHandler));
+
+
+        final JsonEnvelope envelope1 = envelope().with(metadataWithRandomUUID("event-with-handler").withStreamId(streamId).withVersion(1L)).build();
+        final JsonEnvelope envelope2 = envelope().with(metadataWithRandomUUID("event-without-handler").withStreamId(streamId).withVersion(2L)).build();
+        final JsonEnvelope envelope3 = envelope().with(metadataWithRandomUUID("event-with-handler").withStreamId(streamId).withVersion(3L)).build();
+
+        asyncStreamDispatcher.dispatch(Stream.of(envelope1, envelope2, envelope3));
+
+        ArgumentCaptor<JsonEnvelope> dispatchCaptor = ArgumentCaptor.forClass(JsonEnvelope.class);
+
+        verify(envelopeDispatcher, times(3)).dispatch(dispatchCaptor.capture());
+        verify(streamStatusRepository).insert(new StreamStatus(streamId, 3L));
 
     }
 


### PR DESCRIPTION
* If the exception is not caught the stream is not completely processed.
* Some of the events don't have listener and it shouldn't break processing.